### PR TITLE
Fix memory leaks and add widget tests

### DIFF
--- a/lib/screens/bert_chat_screen.dart
+++ b/lib/screens/bert_chat_screen.dart
@@ -74,6 +74,12 @@ class _BertChatScreenState extends State<BertChatScreen> {
   }
 
   @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(title: const Text("BERT Chat Teşhis Asistanı")),

--- a/lib/screens/library_screen.dart
+++ b/lib/screens/library_screen.dart
@@ -14,12 +14,18 @@ class _LibraryScreenState extends State<LibraryScreen> {
   final TextEditingController _searchController = TextEditingController();
   List<Map<String, dynamic>> allDiseases = [];
   String _searchQuery = "";
-  Set<int> _expandedIndexes = {}; // Expanded card indexes
+  Set<int> _expandedIndexes = {}; // Expanded card indices
 
   @override
   void initState() {
     super.initState();
     _loadDiseaseData();
+  }
+
+  @override
+  void dispose() {
+    _searchController.dispose();
+    super.dispose();
   }
 
   Future<void> _loadDiseaseData() async {
@@ -64,8 +70,7 @@ class _LibraryScreenState extends State<LibraryScreen> {
               child: TextField(
                 controller: _searchController,
                 decoration: InputDecoration(
-                  hintText: 'Hastalık ara...'
-                      .replaceAll('ara...', 'isim girin'),
+                  hintText: 'Hastalık ismi girin...',
                   prefixIcon: const Icon(Icons.search),
                   border: OutlineInputBorder(borderRadius: BorderRadius.circular(8)),
                 ),

--- a/test/home_screen_test.dart
+++ b/test/home_screen_test.dart
@@ -1,0 +1,13 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hastalik_analiz/screens/home_screen.dart';
+
+void main() {
+  testWidgets('Home screen shows menu options', (WidgetTester tester) async {
+    await tester.pumpWidget(const MaterialApp(home: HomeScreen()));
+
+    expect(find.text('🍅 Domates Analiz'), findsOneWidget);
+    expect(find.text('💬 BERT Chat Teşhis'), findsOneWidget);
+    expect(find.text('📚 Hastalık Kütüphanesi'), findsOneWidget);
+  });
+}

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -11,20 +11,10 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:hastalik_analiz/main.dart';
 
 void main() {
-  testWidgets('Counter increments smoke test', (WidgetTester tester) async {
-    // Build our app and trigger a frame.
+  testWidgets('Home screen loads with navigation bar', (WidgetTester tester) async {
     await tester.pumpWidget(const MyApp());
 
-    // Verify that our counter starts at 0.
-    expect(find.text('0'), findsOneWidget);
-    expect(find.text('1'), findsNothing);
-
-    // Tap the '+' icon and trigger a frame.
-    await tester.tap(find.byIcon(Icons.add));
-    await tester.pump();
-
-    // Verify that our counter has incremented.
-    expect(find.text('0'), findsNothing);
-    expect(find.text('1'), findsOneWidget);
+    expect(find.text('Domates Teşhis Paneli'), findsOneWidget);
+    expect(find.byType(NavigationDestination), findsNWidgets(4));
   });
 }


### PR DESCRIPTION
## Summary
- dispose controllers in `BertChatScreen` and `LibraryScreen`
- fix search hint text in `LibraryScreen`
- correct comment wording
- improve existing widget test and add new home screen test

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684cb77ce3888322bb938b9b69dcf5a8